### PR TITLE
Update for htmx 1.7.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <VersionPrefix>1.6.1</VersionPrefix>
-        <PackageReleaseNotes>Initial production-ready release</PackageReleaseNotes>
+        <VersionPrefix>1.7.0</VersionPrefix>
+        <PackageReleaseNotes>Support new attributes/headers in htmx 1.7.0</PackageReleaseNotes>
         <Authors>danieljsummers</Authors>
         <Company>Bit Badger Solutions</Company>
         <PackageProjectUrl>https://github.com/bit-badger/Giraffe.Htmx</PackageProjectUrl>

--- a/src/Htmx.Tests/Tests.fs
+++ b/src/Htmx.Tests/Tests.fs
@@ -218,6 +218,17 @@ module HandlerTests =
       }
 
   [<Fact>]
+  let ``withHxNoPush succeeds`` () =
+    let ctx = Substitute.For<HttpContext> ()
+    let dic = HeaderDictionary ()
+    ctx.Response.Headers.ReturnsForAnyArgs dic |> ignore
+    task {
+      let! _ = withHxNoPush next ctx
+      Assert.True (dic.ContainsKey "HX-Push")
+      Assert.Equal ("false", dic.["HX-Push"].[0])
+      }
+
+  [<Fact>]
   let ``withHxRedirect succeeds`` () =
     let ctx = Substitute.For<HttpContext> ()
     let dic = HeaderDictionary ()

--- a/src/Htmx/Htmx.fs
+++ b/src/Htmx/Htmx.fs
@@ -66,6 +66,10 @@ module Handlers =
   let withHxPush : string -> HttpHandler =
     setHttpHeader "HX-Push"
 
+  // Explicitly do not push a new URL into the history stack
+  let withHxNoPush : HttpHandler =
+    toLowerBool false |> withHxPush
+    
   /// Can be used to do a client-side redirect to a new location
   let withHxRedirect : string -> HttpHandler =
     setHttpHeader "HX-Redirect"

--- a/src/Htmx/README.md
+++ b/src/Htmx/README.md
@@ -2,7 +2,7 @@
 
 This package enables server-side support for [htmx](https://htmx.org) within [Giraffe](https://giraffe.wiki) and ASP.NET's `HttpContext`.
 
-**htmx version: 1.6.1**
+**htmx version: 1.7.0**
 
 ### Setup
 

--- a/src/ViewEngine.Htmx.Tests/Tests.fs
+++ b/src/ViewEngine.Htmx.Tests/Tests.fs
@@ -345,6 +345,10 @@ module Attributes =
     p [ _hxDisable ] [] |> shouldRender """<p hx-disable></p>"""
   
   [<Fact>]
+  let ``_hxDisinherit succeeds`` () =
+    strong [ _hxDisinherit "*" ] [] |> shouldRender """<strong hx-disinherit="*"></strong>"""
+  
+  [<Fact>]
   let ``_hxEncoding succeeds`` () =
     form [ _hxEncoding "utf-7" ] [] |> shouldRender """<form hx-encoding="utf-7"></form>"""
   
@@ -425,6 +429,10 @@ module Attributes =
   let ``_hxSwapOob succeeds`` () =
     li [ _hxSwapOob "true" ] [] |> shouldRender """<li hx-swap-oob="true"></li>"""
   
+  [<Fact>]
+  let ``_hxSync succeeds`` () =
+    nav [ _hxSync "closest form:abort" ] [] |> shouldRender """<nav hx-sync="closest form:abort"></nav>"""
+
   [<Fact>]
   let ``_hxTarget succeeds`` () =
     header [ _hxTarget "#somewhereElse" ] [] |> shouldRender """<header hx-target="#somewhereElse"></header>"""

--- a/src/ViewEngine.Htmx.Tests/Tests.fs
+++ b/src/ViewEngine.Htmx.Tests/Tests.fs
@@ -449,4 +449,19 @@ module Attributes =
   [<Fact>]
   let ``_hxWs succeeds`` () =
     ul [ _hxWs "connect:/web-socket" ] [] |> shouldRender """<ul hx-ws="connect:/web-socket"></ul>"""
+
+
+/// Tests for the Script module
+module Script =
   
+  [<Fact>]
+  let ``Script.minified succeeds`` () =
+    let html = RenderView.AsString.htmlNode Script.minified
+    Assert.Equal ("""<script src="https://unpkg.com/htmx.org@1.7.0" integrity="sha384-EzBXYPt0/T6gxNp0nuPtLkmRpmDBbjg6WmCUZRLXBBwYYmwAUxzlSGej0ARHX0Bo" crossorigin="anonymous"></script>""",
+                  html)
+  
+  [<Fact>]
+  let ``Script.unminified succeeds`` () =
+    let html = RenderView.AsString.htmlNode Script.unminified
+    Assert.Equal ("""<script src="https://unpkg.com/htmx.org@1.7.0/dist/htmx.js" integrity="sha384-ESk4PjE7dwjGkEciohREmmf8rLMX0E95MKwxM3bvC90sZ3XbF2TELnVk2w7bX0d9" crossorigin="anonymous"></script>""",
+                  html)

--- a/src/ViewEngine.Htmx/Htmx.fs
+++ b/src/ViewEngine.Htmx/Htmx.fs
@@ -224,15 +224,15 @@ module Script =
   /// Script tag to load the minified version from unpkg.com
   let minified =
     script [
-      _src         "https://unpkg.com/htmx.org@1.6.1"
-      _integrity   "sha384-tvG/2mnCFmGQzYC1Oh3qxQ7CkQ9kMzYjWZSNtrRZygHPDDqottzEJsqS4oUVodhW"
+      _src         "https://unpkg.com/htmx.org@1.7.0"
+      _integrity   "sha384-EzBXYPt0/T6gxNp0nuPtLkmRpmDBbjg6WmCUZRLXBBwYYmwAUxzlSGej0ARHX0Bo"
       _crossorigin "anonymous"
       ] []
 
   /// Script tag to load the unminified version from unpkg.com
   let unminified =
     script [
-      _src         "https://unpkg.com/htmx.org@1.6.1/dist/htmx.js"
-      _integrity   "sha384-7G9OE6gS4pBnBGH74HojjPQ8xOEGrdBeQc7JJOc58k6LG/YVfKXARd91w9715AYG"
+      _src         "https://unpkg.com/htmx.org@1.7.0/dist/htmx.js"
+      _integrity   "sha384-ESk4PjE7dwjGkEciohREmmf8rLMX0E95MKwxM3bvC90sZ3XbF2TELnVk2w7bX0d9"
       _crossorigin "anonymous"
       ] []

--- a/src/ViewEngine.Htmx/Htmx.fs
+++ b/src/ViewEngine.Htmx/Htmx.fs
@@ -164,6 +164,8 @@ module HtmxAttrs =
   let _hxDelete     = attr "hx-delete"
   /// Disables htmx processing for the given node and any children nodes
   let _hxDisable    = flag "hx-disable"
+  /// Disinherit all ("*") or specific htmx attributes
+  let _hxDisinherit = attr "hx-disinherit"
   /// Changes the request encoding type
   let _hxEncoding   = attr "hx-encoding"
   /// Extensions to use for this element
@@ -204,6 +206,8 @@ module HtmxAttrs =
   let _hxSwap       = attr "hx-swap"
   /// Marks content in a response as being "Out of Band", i.e. swapped somewhere other than the target
   let _hxSwapOob    = attr "hx-swap-oob"
+  /// Synchronize events based on another element
+  let _hxSync       = attr "hx-sync"
   /// Specifies the target element to be swapped
   let _hxTarget     = attr "hx-target"
   /// Specifies the event that triggers the request

--- a/src/ViewEngine.Htmx/README.md
+++ b/src/ViewEngine.Htmx/README.md
@@ -2,7 +2,7 @@
 
 This package enables [htmx](https://htmx.org) support within the [Giraffe](https://giraffe.wiki) view engine.
 
-**htmx version: 1.6.1**
+**htmx version: 1.7.0**
 
 ### Setup
 


### PR DESCRIPTION
* Add `withHxNoPush` handler to support the `HX-Push=false` header
* Add `_hxDisinherit` and `_hxSync` attributes
* Update release/version-specific files